### PR TITLE
Added entry point to cli

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -184,3 +184,6 @@ cli.add_command(metric)
 cli.add_command(chmod)
 # Debug commands
 cli.add_command(space)
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Addresses https://github.com/umd-huang-lab/WAVES/issues/10.

The CLI currently lacks a proper entry point, which prevents it from working as intended.
This PR adds a minimal entry point at the end of `cli.py` to restore expected CLI functionality.
